### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/resources/templates/security/scan.html
+++ b/src/main/resources/templates/security/scan.html
@@ -621,13 +621,22 @@
             // Add a scan to the recent scans table
             function addToRecentScans(scan) {
                 const statusBadge = getStatusBadge(scan.status);
+                const escapeHtml = (unsafe) => {
+                    return unsafe
+                        .replace(/&/g, "&amp;")
+                        .replace(/</g, "&lt;")
+                        .replace(/>/g, "&gt;")
+                        .replace(/"/g, "&quot;")
+                        .replace(/'/g, "&#039;");
+                };
+                
                 const newRow = `
                     <tr>
                         <td>${scan.time}</td>
-                        <td>${scan.visitorName}</td>
+                        <td>${escapeHtml(scan.visitorName)}</td>
                         <td>${statusBadge}</td>
                         <td>
-                            <button class="btn btn-sm btn-outline-primary view-scan-btn" data-visitor-id="${scan.visitorId}">
+                            <button class="btn btn-sm btn-outline-primary view-scan-btn" data-visitor-id="${escapeHtml(scan.visitorId)}">
                                 <i class="fas fa-eye"></i>
                             </button>
                         </td>


### PR DESCRIPTION
Potential fix for [https://github.com/SylvesterOgaOgaji/fct-visitation-system/security/code-scanning/3](https://github.com/SylvesterOgaOgaji/fct-visitation-system/security/code-scanning/3)

To fix the issue, we need to ensure that any user-controlled data interpolated into the `newRow` string is properly escaped to prevent XSS. The best approach is to use a library like `lodash` or `DOMPurify` to escape or sanitize the `visitorId` value before it is used. Alternatively, we can use jQuery's `.text()` method to safely insert text into the DOM instead of interpolating it into an HTML string.

In this case, we will escape the `visitorId` value using a utility function to ensure that it is safe for use in the DOM. This function will replace special HTML characters (e.g., `<`, `>`, `&`, `"`, `'`) with their corresponding HTML entities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
