### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/resources/templates/security/checkpoint.html
+++ b/src/main/resources/templates/security/checkpoint.html
@@ -621,13 +621,21 @@
             // Add a scan to the recent scans table
             function addToRecentScans(scan) {
                 const statusBadge = getStatusBadge(scan.status);
+                const escapeHtml = (str) => {
+                    return str.replace(/&/g, "&amp;")
+                              .replace(/</g, "&lt;")
+                              .replace(/>/g, "&gt;")
+                              .replace(/"/g, "&quot;")
+                              .replace(/'/g, "&#039;");
+                };
+                
                 const newRow = `
                     <tr>
                         <td>${scan.time}</td>
-                        <td>${scan.visitorName}</td>
+                        <td>${escapeHtml(scan.visitorName)}</td>
                         <td>${statusBadge}</td>
                         <td>
-                            <button class="btn btn-sm btn-outline-primary view-scan-btn" data-visitor-id="${scan.visitorId}">
+                            <button class="btn btn-sm btn-outline-primary view-scan-btn" data-visitor-id="${escapeHtml(scan.visitorId)}">
                                 <i class="fas fa-eye"></i>
                             </button>
                         </td>


### PR DESCRIPTION
Potential fix for [https://github.com/SylvesterOgaOgaji/fct-visitation-system/security/code-scanning/4](https://github.com/SylvesterOgaOgaji/fct-visitation-system/security/code-scanning/4)

To fix the issue, we need to ensure that any user-controlled data, such as `visitorId`, is properly escaped before being inserted into the DOM. This can be achieved by using a library like `lodash` or `DOMPurify` to sanitize the input or by manually escaping HTML special characters. The best approach here is to use a utility function to escape the `visitorId` value before including it in the `newRow` string. This ensures that any malicious input is rendered harmless.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
